### PR TITLE
refactor: register REST controllers as resource classes instead of provider singletons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>13.2.1</version>
+        <version>14.0.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.test-data</artifactId>

--- a/src/main/java/ch/sbb/polarion/extension/test_data/rest/TestDataRestApplication.java
+++ b/src/main/java/ch/sbb/polarion/extension/test_data/rest/TestDataRestApplication.java
@@ -11,10 +11,10 @@ public class TestDataRestApplication extends GenericRestApplication {
 
     @Override
     @NotNull
-    protected Set<Object> getExtensionControllerSingletons() {
+    protected Set<Class<?>> getExtensionControllerClasses() {
         return Set.of(
-                new TestDataApiController(),
-                new TestDataInternalController()
+                TestDataApiController.class,
+                TestDataInternalController.class
         );
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataApiController.java
@@ -3,9 +3,11 @@ package ch.sbb.polarion.extension.test_data.rest.controller;
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
+@Singleton
 @Secured
 @Path("/api")
 public class TestDataApiController extends TestDataInternalController {

--- a/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataInternalController.java
@@ -13,6 +13,7 @@ import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.jetbrains.annotations.Nullable;
 
+import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -30,6 +31,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.InputStream;
 import java.net.URI;
 
+@Singleton
 @Tag(name = "Test Data")
 @Hidden
 @Path("/internal")


### PR DESCRIPTION
### Proposed changes

Move controller registration from getExtensionControllerSingletons() to getExtensionControllerClasses() and add @Singleton annotations to fix Jersey warning about controllers registered as providers.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
