### PR TITLE
refactor: revert from InputStream to FormDataBodyPart

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -465,10 +465,14 @@
               "schema": {
                 "properties": {
                   "file": {
+                    "description": "Project template file",
                     "format": "binary",
                     "type": "string"
                   }
                 },
+                "required": [
+                  "file"
+                ],
                 "type": "object"
               }
             }

--- a/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataApiController.java
@@ -4,12 +4,11 @@ import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import ch.sbb.polarion.extension.test_data.rest.model.CollectionRequest;
 import ch.sbb.polarion.extension.test_data.rest.model.CrossDocumentLinksRequest;
 import ch.sbb.polarion.extension.test_data.rest.model.LinkedRevisionsRequest;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
-
-import java.io.InputStream;
 
 @Singleton
 @Secured
@@ -32,7 +31,7 @@ public class TestDataApiController extends TestDataInternalController {
     }
 
     @Override
-    public Response saveProjectTemplate(String templateId, String templateHash, InputStream file) {
+    public Response saveProjectTemplate(String templateId, String templateHash, FormDataBodyPart file) {
         return polarionService.callPrivileged(() -> super.saveProjectTemplate(templateId, templateHash, file));
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/test_data/rest/controller/TestDataInternalController.java
@@ -17,10 +17,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.SchemaProperty;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.jetbrains.annotations.Nullable;
 
@@ -133,14 +132,11 @@ public class TestDataInternalController {
                     @ApiResponse(responseCode = "400", description = "Invalid template data or ID")
             }
     )
-    @RequestBody(content = @Content(
-            mediaType = MediaType.MULTIPART_FORM_DATA,
-            schemaProperties = @SchemaProperty(name = "file", schema = @Schema(type = "string", format = "binary"))
-    ))
     public Response saveProjectTemplate(
             @PathParam("templateId") String templateId,
             @PathParam("templateHash") String templateHash,
-            @FormDataParam("file") InputStream file
+            @Parameter(description = "Project template file", required = true, schema = @Schema(type = "string", format = "binary"))
+            @FormDataParam("file") FormDataBodyPart file
     ) {
 
         if (templateId == null || templateId.trim().isEmpty()) {
@@ -154,7 +150,9 @@ public class TestDataInternalController {
         try {
             polarionService.callPrivileged(() -> TransactionalExecutor.executeInWriteTransaction(
                     transaction -> {
-                        projectTemplateService.saveProjectTemplate(templateId, file, templateHash);
+                        InputStream inputStream = file.getValueAs(InputStream.class);
+
+                        projectTemplateService.saveProjectTemplate(templateId, inputStream, templateHash);
                         return null;
                     })
             );


### PR DESCRIPTION
### Proposed changes

This pull request updates the handling of project template file uploads in the REST API to improve type safety and documentation. The main changes involve switching from using `InputStream` to `FormDataBodyPart` for the uploaded file, updating OpenAPI documentation, and ensuring the file is properly extracted for processing.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
